### PR TITLE
Added support for Gruntfile.coffee

### DIFF
--- a/lib/Grunt.js
+++ b/lib/Grunt.js
@@ -18,7 +18,7 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      return fs.existsSync(path.join(this.cwd, 'Gruntfile.js')) || fs.existsSync(path.join(this.cwd, 'Gruntfile.coffee'));
+      return fs.existsSync(path.join(this.cwd, 'Gruntfile.js')) || fs.existsSync(path.join(this.cwd, 'Gruntfile.coffee'));
     }
 
     settings() {

--- a/lib/Grunt.js
+++ b/lib/Grunt.js
@@ -18,7 +18,7 @@ export function provideBuilder() {
     }
 
     isEligible() {
-      return fs.existsSync(path.join(this.cwd, 'Gruntfile.js'));
+      return fs.existsSync(path.join(this.cwd, 'Gruntfile.js')) || fs.existsSync(path.join(this.cwd, 'Gruntfile.coffee'));
     }
 
     settings() {

--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -25,7 +25,11 @@ module.exports = function (path) {
     window = undefined;
     /* eslint-enable no-native-reassign, no-undef */
 
-    require(path + '/Gruntfile.js')(grunt);
+    if (fs.existsSync(path + '/Gruntfile.coffee')) {
+      require(path + '/Gruntfile.coffee')(grunt);
+    } else {
+      require(path + '/Gruntfile.js')(grunt);
+    }
     return { tasks: Object.keys(grunt.task._tasks) };
   } catch (e) {
     return { error: { message: e.message } };

--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -1,5 +1,7 @@
 'use babel';
 
+import fs from 'fs';
+
 /**
  * This has to be done in a separate task since Grunt depends
  * on stuff that does unsafe evals. We don't want, and are not

--- a/spec/fixture/Gruntfile.coffee
+++ b/spec/fixture/Gruntfile.coffee
@@ -1,0 +1,18 @@
+module.exports = (grunt) ->
+  'use strict'
+
+  grunt.initConfig {}
+
+  grunt.registerTask 'other task', ->
+    console.log 'doing heavy machinery stuff'
+    return
+
+  grunt.registerTask 'default', ->
+    console.log 'Surprising is the passing of time. But not so, as the time of passing'
+    return
+
+  grunt.registerTask 'dev task', ->
+    console.log 'doing dev build'
+    return
+
+  return


### PR DESCRIPTION
Hi!

While using this atom-build plugin in Atom I've noticed that my Grunt tasks weren't listed even when refreshed once I switched/converted from Gruntfile.js to Gruntfile.coffee. So I decided to fork your repository and added the support thereof. Hope you accept this pull request.

Best regards,
Sven
