### PR TITLE
Fix for task parser

### DIFF
--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -28,6 +28,7 @@ module.exports = function (path) {
     /* eslint-enable no-native-reassign, no-undef */
 
     /* Some tasks wants to write something to stdout, so let's fake it till you make it. */
+    let stdoutWrite = process.stdout.write;
     process.stdout.write = function () {};
 
     if (fs.existsSync(path + '/Gruntfile.coffee')) {
@@ -35,6 +36,11 @@ module.exports = function (path) {
     } else {
       require(path + '/Gruntfile.js')(grunt);
     }
+    
+    /* Restore the stdout.write */
+    process.stdout.write = stdoutWrite;
+    stdoutWrite = undefined;
+    
     return { tasks: Object.keys(grunt.task._tasks) };
   } catch (e) {
     return { error: { message: e.message } };

--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -36,11 +36,11 @@ module.exports = function (path) {
     } else {
       require(path + '/Gruntfile.js')(grunt);
     }
-    
+
     /* Restore the stdout.write */
     process.stdout.write = stdoutWrite;
     stdoutWrite = undefined;
-    
+
     return { tasks: Object.keys(grunt.task._tasks) };
   } catch (e) {
     return { error: { message: e.message } };

--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -27,6 +27,9 @@ module.exports = function (path) {
     window = undefined;
     /* eslint-enable no-native-reassign, no-undef */
 
+    /* Some tasks wants to write something to stdout, so let's fake it till you make it. */
+    process.stdout.write = function() {};
+
     if (fs.existsSync(path + '/Gruntfile.coffee')) {
       require(path + '/Gruntfile.coffee')(grunt);
     } else {

--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -28,7 +28,7 @@ module.exports = function (path) {
     /* eslint-enable no-native-reassign, no-undef */
 
     /* Some tasks wants to write something to stdout, so let's fake it till you make it. */
-    process.stdout.write = function() {};
+    process.stdout.write = function () {};
 
     if (fs.existsSync(path + '/Gruntfile.coffee')) {
       require(path + '/Gruntfile.coffee')(grunt);


### PR DESCRIPTION
Some packages - for example [grunt-mocha-test](https://www.npmjs.com/package/grunt-mocha-test) - break the task parser (resulting in just 1 task: `default`), because those packages write something to `stdout` during construction. This small fix attaches an empty function to `stdout.write` to overcome this problem.

You can reproduce this behavior, by adding grunt-mocha-test to a Gruntfile.js. The task list won't load. After applying this small fix it will. Please merge and publish to npm :-) Thanks!
